### PR TITLE
fix: dependency tree for destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,4 +9,6 @@ resource "ibm_cr_retention_policy" "cr_retention_policy" {
   namespace       = ibm_cr_namespace.cr_namespace.name
   images_per_repo = var.images_per_repo
   retain_untagged = var.retain_untagged != null ? var.retain_untagged : false
+  # Issue 128: to ensure policy fully destroyed before namespace
+  depends_on = [ibm_cr_namespace.cr_namespace]
 }


### PR DESCRIPTION
### Description

#128 also refer to comments in internal issue 7860 before approving

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

There should be no upgrade issues since this is a dependency tree change. It may resolve a race condition where the policy fails to create because the namespace is not available, or fails to destroy because the namespace is already destroyed.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
