### PR TITLE
fix: sync mapping of regions to endpoints in deployable architecture

### DIFF
--- a/modules/plan/README.md
+++ b/modules/plan/README.md
@@ -2,7 +2,7 @@
 
 You can use this submodule to upgrade the IBM [Container Registry](https://cloud.ibm.com/docs/Registry?topic=Registry-registry_overview#registry_plans) plan.
 
-The submodule can used without the root module upgrade the plan without creating any additional namespaces or retention polcies.
+The submodule can used without the root module to upgrade the plan without creating any additional namespaces or retention policies.
 
 ### Usage
 ```

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -1,3 +1,4 @@
+# map endpoints found from 'ibmcloud cr region-set'
 locals {
   endpoints = {
     "ap-north"   = "jp.icr.io"
@@ -9,6 +10,7 @@ locals {
     "ca-tor"     = "ca.icr.io"
     "eu-central" = "de.icr.io"
     "eu-es"      = "es.icr.io"
+    "eu-fr2"     = "fr2.icr.io"
     "jp-osa"     = "jp2.icr.io"
     "uk-south"   = "uk.icr.io"
     "global"     = "icr.io"

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "existing_namespace_name" {
   description = "The name of an existing namespace. Required if 'namespace_name' is not provided."
   default     = null
 
-  # exisiting_namespace_name can be NULL. If not NULL then atleast one namespace should match in existing_cr_namespaces list that matches existing_namespace_name
+  # existing_namespace_name can be NULL. If not NULL then atleast one namespace should match in existing_cr_namespaces list that matches existing_namespace_name
   validation {
     condition     = var.existing_namespace_name == null || length([for namespace in data.ibm_cr_namespaces.existing_cr_namespaces.namespaces : namespace if namespace.name == var.existing_namespace_name]) > 0
     error_message = "Existing namespace not found in the region"


### PR DESCRIPTION
### Description

Sync the map of regions to endpoints in the DA with the output of 'ibmcloud cr region-set'

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
