### PR TITLE
fix: Remove github readme from DA tile

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -241,7 +241,8 @@
             {
               "key": "traffic_megabytes"
             }
-          ]
+          ],
+          "ignore_readme": true
         }
       ]
     }


### PR DESCRIPTION

### Description

Removed the github readme from DA tile. Set `"ignore_readme": true` in each variation within the `ibm_catalog.json`.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Removed the github readme from DA tile.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
