### PR TITLE
fix: update description of resource_tags/tags and access_tags and added extra validation to ensure access tags exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ You can use this module to provision and configure an [IBM Container Registry](h
 * [Examples](./examples)
 :information_source: Ctrl/Cmd+Click or right-click on the Schematics deploy button to open in a new tab
     * <a href="./examples/complete">IBM Container Registry namespace example</a> <a href="https://cloud.ibm.com/schematics/workspaces/create?workspace_name=container-registry-complete-example&repository=https://github.com/terraform-ibm-modules/terraform-ibm-container-registry/tree/main/examples/complete"><img src="https://img.shields.io/badge/Deploy%20with IBM%20Cloud%20Schematics-0f62fe?logo=ibm&logoColor=white&labelColor=0f62fe" alt="Deploy with IBM Cloud Schematics" style="height: 16px; vertical-align: text-bottom; margin-left: 5px;"></a>
-* [Deployable Architectures](./solutions)
-    * <a href="./solutions/fully-configurable">Cloud automation for Container Registry (Fully configurable)</a>
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 
@@ -88,19 +86,20 @@ module "set_quota" {
 | [ibm_resource_tag.resource_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [time_sleep.wait_for_namespace](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_cr_namespaces.existing_cr_namespaces](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/cr_namespaces) | data source |
+| [ibm_iam_access_tag.access_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/iam_access_tag) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | Optional list of access management tags to be added to the IBM container namespace. | `list(string)` | `[]` | no |
+| <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | Add access management tags to the Container Registry instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console). | `list(string)` | `[]` | no |
 | <a name="input_cbr_rules"></a> [cbr\_rules](#input\_cbr\_rules) | The list of context-based restriction rules to create for the namespace. | <pre>list(object({<br/>    description = string<br/>    account_id  = string<br/>    rule_contexts = list(object({<br/>      attributes = optional(list(object({<br/>        name  = string<br/>        value = string<br/>    }))) }))<br/>    enforcement_mode = string<br/>    tags = optional(list(object({<br/>      name  = string<br/>      value = string<br/>    })), [])<br/>    operations = optional(list(object({<br/>      api_types = list(object({<br/>        api_type_id = string<br/>      }))<br/>    })))<br/>  }))</pre> | `[]` | no |
 | <a name="input_existing_namespace_name"></a> [existing\_namespace\_name](#input\_existing\_namespace\_name) | The name of an existing namespace. Required if 'namespace\_name' is not provided. | `string` | `null` | no |
 | <a name="input_images_per_repo"></a> [images\_per\_repo](#input\_images\_per\_repo) | (Optional, Integer) Determines how many images are retained in each repository when the retention policy is processed. The value -1 denotes Unlimited (all images are retained). The value 0 denotes no retention policy will be created (default) | `number` | `0` | no |
 | <a name="input_namespace_name"></a> [namespace\_name](#input\_namespace\_name) | Name of the container registry namespace, if var.existing\_namespace\_name is not inputted, a new namespace will be created in a region set by provider. | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the IBM container namespace will be created. | `string` | n/a | yes |
 | <a name="input_retain_untagged"></a> [retain\_untagged](#input\_retain\_untagged) | (Optional, Bool) Determines whether untagged images are retained when the retention policy is processed. Default value is false, means untagged images can be deleted when the policy runs. | `bool` | `false` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Optional list of user tags to be added to the IBM container namespace. | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types). | `list(string)` | `[]` | no |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can use this module to provision and configure an [IBM Container Registry](h
 * [Examples](./examples)
 :information_source: Ctrl/Cmd+Click or right-click on the Schematics deploy button to open in a new tab
     * <a href="./examples/complete">IBM Container Registry namespace example</a> <a href="https://cloud.ibm.com/schematics/workspaces/create?workspace_name=container-registry-complete-example&repository=https://github.com/terraform-ibm-modules/terraform-ibm-container-registry/tree/main/examples/complete"><img src="https://img.shields.io/badge/Deploy%20with IBM%20Cloud%20Schematics-0f62fe?logo=ibm&logoColor=white&labelColor=0f62fe" alt="Deploy with IBM Cloud Schematics" style="height: 16px; vertical-align: text-bottom; margin-left: 5px;"></a>
+* [Deployable Architectures](./solutions)
+    * <a href="./solutions/fully-configurable">Cloud automation for Container Registry (Fully configurable)</a>
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 
@@ -98,8 +100,8 @@ module "set_quota" {
 | <a name="input_images_per_repo"></a> [images\_per\_repo](#input\_images\_per\_repo) | (Optional, Integer) Determines how many images are retained in each repository when the retention policy is processed. The value -1 denotes Unlimited (all images are retained). The value 0 denotes no retention policy will be created (default) | `number` | `0` | no |
 | <a name="input_namespace_name"></a> [namespace\_name](#input\_namespace\_name) | Name of the container registry namespace, if var.existing\_namespace\_name is not inputted, a new namespace will be created in a region set by provider. | `string` | n/a | yes |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the IBM container namespace will be created. | `string` | n/a | yes |
+| <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types). | `list(string)` | `[]` | no |
 | <a name="input_retain_untagged"></a> [retain\_untagged](#input\_retain\_untagged) | (Optional, Bool) Determines whether untagged images are retained when the retention policy is processed. Default value is false, means untagged images can be deleted when the policy runs. | `bool` | `false` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types). | `list(string)` | `[]` | no |
 
 ### Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,7 +71,7 @@ module "namespace" {
   namespace_name          = var.prefix == null ? "namespace" : "${var.prefix}-namespace"
   existing_namespace_name = var.existing_namespace_name
   resource_group_id       = module.resource_group.resource_group_id
-  tags                    = var.resource_tags
+  resource_tags           = var.resource_tags
   access_tags             = var.access_tags
   images_per_repo         = var.images_per_repo
   retain_untagged         = var.retain_untagged

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -30,13 +30,13 @@ variable "resource_group" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
+  description = "Tags that should be applied to the namespace"
   default     = ["test-icr-tag", "test-icr"]
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Add access management tags to the Container Registry instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
+  description = "Access management tags to be added to the IBM container namespace."
   default     = []
 }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -30,13 +30,13 @@ variable "resource_group" {
 
 variable "resource_tags" {
   type        = list(string)
-  description = "Tags that should be applied to the namespace"
+  description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = ["test-icr-tag", "test-icr"]
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Access management tags to be added to the IBM container namespace."
+  description = "Add access management tags to the Container Registry instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   default     = []
 }
 

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -170,7 +170,7 @@
               "key": "existing_namespace_name"
             },
             {
-              "key": "tags",
+              "key": "resource_tags",
               "type": "array",
               "custom_config": {
                 "grouping": "deployment",

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "ibm_cr_namespace" "cr_namespace" {
   count             = var.existing_namespace_name != null ? 0 : 1
   name              = var.namespace_name
   resource_group_id = var.resource_group_id
-  tags              = var.tags
+  tags              = var.resource_tags
 }
 
 # workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6614
@@ -37,9 +37,9 @@ data "ibm_iam_access_tag" "access_tag" {
 }
 
 resource "ibm_resource_tag" "resource_tag" {
-  count       = var.existing_namespace_name != null || length(var.tags) == 0 ? 0 : 1
+  count       = var.existing_namespace_name != null || length(var.resource_tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
-  tags        = var.tags
+  tags        = var.resource_tags
   tag_type    = "user"
   depends_on  = [time_sleep.wait_for_namespace]
 }

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,11 @@ resource "time_sleep" "wait_for_namespace" {
 }
 
 # In addition to locally managed tags on the ibm_cr_namespace resource because https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cr_namespace#tags-5
+data "ibm_iam_access_tag" "access_tag" {
+  for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
+  name     = each.value
+}
+
 resource "ibm_resource_tag" "resource_tag" {
   count       = var.existing_namespace_name != null || length(var.tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
@@ -44,7 +49,7 @@ resource "ibm_resource_tag" "access_tag" {
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
   tags        = var.access_tags
   tag_type    = "access"
-  depends_on  = [time_sleep.wait_for_namespace]
+  depends_on  = [time_sleep.wait_for_namespace, data.ibm_iam_access_tag.access_tag]
 }
 
 resource "ibm_cr_retention_policy" "cr_retention_policy" {

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "ibm_cr_namespace" "cr_namespace" {
   count             = var.existing_namespace_name != null ? 0 : 1
   name              = var.namespace_name
   resource_group_id = var.resource_group_id
-  tags              = var.tags
+  tags              = var.resource_tags
 }
 
 # In addition to locally managed tags on the ibm_cr_namespace resource because https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cr_namespace#tags-5
@@ -36,6 +36,7 @@ resource "ibm_resource_tag" "resource_tag" {
 }
 
 resource "ibm_resource_tag" "access_tag" {
+  depends_on  = [data.ibm_iam_access_tag.access_tag]
   count       = var.existing_namespace_name != null || length(var.access_tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
   tags        = var.access_tags

--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,6 @@ resource "ibm_cr_namespace" "cr_namespace" {
 }
 
 # In addition to locally managed tags on the ibm_cr_namespace resource because https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cr_namespace#tags-5
-data "ibm_iam_access_tag" "access_tag" {
-  for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
-  name     = each.value
-}
-
 resource "ibm_resource_tag" "resource_tag" {
   count       = var.existing_namespace_name != null || length(var.resource_tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
@@ -35,8 +30,13 @@ resource "ibm_resource_tag" "resource_tag" {
   tag_type    = "user"
 }
 
+data "ibm_iam_access_tag" "access_tag" {
+  for_each = length(var.access_tags) != 0 ? toset(var.access_tags) : []
+  name     = each.value
+}
+
 resource "ibm_resource_tag" "access_tag" {
-  depends_on  = [data.ibm_iam_access_tag.access_tag]
+  depends_on  = [data.ibm_iam_access_tag.access_tag] # Force dependency on data source validation to ensure access_tags exist and are valid before use.
   count       = var.existing_namespace_name != null || length(var.access_tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
   tags        = var.access_tags

--- a/solutions/fully-configurable/catalogValidationValues.json.template
+++ b/solutions/fully-configurable/catalogValidationValues.json.template
@@ -3,5 +3,5 @@
   "prefix": $PREFIX,
   "existing_resource_group_name": "geretain-test-icr",
   "namespace_region": "us-south",
-  "tags": $TAGS
+  "resource_tags": $TAGS
 }

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -16,7 +16,7 @@ module "namespace" {
   source            = "../.."
   namespace_name    = (var.prefix != null && var.prefix != "") ? "${var.prefix}-${var.namespace_name}" : var.namespace_name
   resource_group_id = module.resource_group.resource_group_id
-  tags              = var.tags
+  resource_tags     = var.resource_tags
   access_tags       = var.access_tags
   images_per_repo   = var.images_per_repo
   retain_untagged   = var.retain_untagged

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -73,7 +73,7 @@ variable "existing_namespace_name" {
   default     = null
 }
 
-variable "tags" {
+variable "resource_tags" {
   type        = list(string)
   description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -75,13 +75,13 @@ variable "existing_namespace_name" {
 
 variable "tags" {
   type        = list(string)
-  description = "Optional list of tags to be added to the IBM container namespace."
+  description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Optional list of access management tags to be added to the IBM container namespace."
+  description = "Add access management tags to the Container Registry instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,12 +38,12 @@ variable "resource_group_id" {
   description = "The resource group ID where the IBM container namespace will be created."
 }
 
-variable "tags" {
+variable "resource_tags" {
   type        = list(string)
   description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []
   validation {
-    condition     = alltrue([for tag in var.tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
     error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,13 +40,17 @@ variable "resource_group_id" {
 
 variable "tags" {
   type        = list(string)
-  description = "Optional list of user tags to be added to the IBM container namespace."
+  description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []
+  validation {
+    condition     = alltrue([for tag in var.tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
+  }
 }
 
 variable "access_tags" {
   type        = list(string)
-  description = "Optional list of access management tags to be added to the IBM container namespace."
+  description = "Add access management tags to the Container Registry instance to control access. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console)."
   default     = []
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "resource_tags" {
   description = "Add user resource tags to the Container Registry instance to organize, track, and manage costs. [Learn more](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#tag-types)."
   default     = []
   validation {
-    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:](1, 128)$", tag))])
+    condition     = alltrue([for tag in var.resource_tags : can(regex("^[A-Za-z0-9 _\\-.:]{1,128}$", tag))])
     error_message = "Each resource tag must be 128 characters or less and may contain only A-Z, a-z, 0-9, spaces, underscore (_), hyphen (-), period (.), and colon (:)."
   }
 }


### PR DESCRIPTION
### Description

This PR updates:
- tags -> resource_tags
- resource_tags variable description and validation
- access_tags variable description
- Adds data block to ensure existing access_tags are being attached to the instance

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
This release contains the following updates: 

- Renamed `tags` to `resource_tags` for improved clarity and consistency. As well as enhanced `resource_tags` variable description and added validation.

- Refined `access_tags` variable description for clearer understanding.

- Added a data block to ensure existing `access_tags` are correctly attached to the instance.

- If the DA is being used and IF `tags` have been set they need to be manually copied/added in the replacement `resource_tags` field in the UI.