### PR TITLE
fix: bump minimum provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can use this module to provision and configure an [IBM Container Registry](h
 * [Examples](./examples)
 :information_source: Ctrl/Cmd+Click or right-click on the Schematics deploy button to open in a new tab
     * <a href="./examples/complete">IBM Container Registry namespace example</a> <a href="https://cloud.ibm.com/schematics/workspaces/create?workspace_name=container-registry-complete-example&repository=https://github.com/terraform-ibm-modules/terraform-ibm-container-registry/tree/main/examples/complete"><img src="https://img.shields.io/badge/Deploy%20with IBM%20Cloud%20Schematics-0f62fe?logo=ibm&logoColor=white&labelColor=0f62fe" alt="Deploy with IBM Cloud Schematics" style="height: 16px; vertical-align: text-bottom; margin-left: 5px;"></a>
+* [Deployable Architectures](./solutions)
+    * <a href="./solutions/fully-configurable">Cloud automation for Container Registry (Fully configurable)</a>
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ You can use this module to provision and configure an [IBM Container Registry](h
 * [Examples](./examples)
 :information_source: Ctrl/Cmd+Click or right-click on the Schematics deploy button to open in a new tab
     * <a href="./examples/complete">IBM Container Registry namespace example</a> <a href="https://cloud.ibm.com/schematics/workspaces/create?workspace_name=container-registry-complete-example&repository=https://github.com/terraform-ibm-modules/terraform-ibm-container-registry/tree/main/examples/complete"><img src="https://img.shields.io/badge/Deploy%20with IBM%20Cloud%20Schematics-0f62fe?logo=ibm&logoColor=white&labelColor=0f62fe" alt="Deploy with IBM Cloud Schematics" style="height: 16px; vertical-align: text-bottom; margin-left: 5px;"></a>
-* [Deployable Architectures](./solutions)
-    * <a href="./solutions/fully-configurable">Cloud automation for Container Registry (Fully configurable)</a>
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 
@@ -69,8 +67,7 @@ module "set_quota" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.89.0, < 2.0.0 |
 
 ### Modules
 
@@ -86,7 +83,6 @@ module "set_quota" {
 | [ibm_cr_retention_policy.cr_retention_policy](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cr_retention_policy) | resource |
 | [ibm_resource_tag.access_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [ibm_resource_tag.resource_tag](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/resource_tag) | resource |
-| [time_sleep.wait_for_namespace](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_cr_namespaces.existing_cr_namespaces](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/cr_namespaces) | data source |
 
 ### Inputs

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -7,7 +7,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.79.0"
+      version = "1.89.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/main.tf
+++ b/main.tf
@@ -22,21 +22,12 @@ resource "ibm_cr_namespace" "cr_namespace" {
   tags              = var.tags
 }
 
-# workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6614
-resource "time_sleep" "wait_for_namespace" {
-  count      = var.existing_namespace_name != null ? 0 : 1
-  depends_on = [ibm_cr_namespace.cr_namespace]
-
-  create_duration = "10s"
-}
-
 # In addition to locally managed tags on the ibm_cr_namespace resource because https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cr_namespace#tags-5
 resource "ibm_resource_tag" "resource_tag" {
   count       = var.existing_namespace_name != null || length(var.tags) == 0 ? 0 : 1
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
   tags        = var.tags
   tag_type    = "user"
-  depends_on  = [time_sleep.wait_for_namespace]
 }
 
 resource "ibm_resource_tag" "access_tag" {
@@ -44,7 +35,6 @@ resource "ibm_resource_tag" "access_tag" {
   resource_id = ibm_cr_namespace.cr_namespace[0].crn
   tags        = var.access_tags
   tag_type    = "access"
-  depends_on  = [time_sleep.wait_for_namespace]
 }
 
 resource "ibm_cr_retention_policy" "cr_retention_policy" {

--- a/modules/endpoint/README.md
+++ b/modules/endpoint/README.md
@@ -19,7 +19,7 @@ module "cr_endpoint" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.89.0, < 2.0.0 |
 
 ### Modules
 

--- a/modules/endpoint/version.tf
+++ b/modules/endpoint/version.tf
@@ -5,7 +5,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.79.0, < 2.0.0"
+      version = ">= 1.89.0, < 2.0.0"
     }
   }
 }

--- a/modules/plan/README.md
+++ b/modules/plan/README.md
@@ -61,7 +61,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.89.0, < 2.0.0 |
 | <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 2.0.1, < 3.0.0 |
 
 ### Modules

--- a/modules/plan/version.tf
+++ b/modules/plan/version.tf
@@ -5,7 +5,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.79.0, < 2.0.0"
+      version = ">= 1.89.0, < 2.0.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/modules/quotas/README.md
+++ b/modules/quotas/README.md
@@ -45,7 +45,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.89.0, < 2.0.0 |
 | <a name="requirement_restapi"></a> [restapi](#requirement\_restapi) | >= 2.0.1, < 3.0.0 |
 
 ### Modules

--- a/modules/quotas/version.tf
+++ b/modules/quotas/version.tf
@@ -5,7 +5,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.79.0, < 2.0.0"
+      version = ">= 1.89.0, < 2.0.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.87.3"
+      version = "1.89.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/tests/existing-resources/provider.tf
+++ b/tests/existing-resources/provider.tf
@@ -6,12 +6,6 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
 }
 
-provider "ibm" {
-  alias            = "namespace"
-  ibmcloud_api_key = var.ibmcloud_api_key
-  region           = var.namespace_region
-}
-
 # Data source to retrieve token details
 data "ibm_iam_auth_token" "token_data" {
 }

--- a/tests/existing-resources/variables.tf
+++ b/tests/existing-resources/variables.tf
@@ -4,12 +4,6 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
-variable "namespace_region" {
-  type        = string
-  description = "The IBM Cloud region where the container registry namespace and retention policy will be created or where the existing namespace is located."
-  default     = "us-south"
-}
-
 variable "resource_group" {
   type        = string
   description = "An existing resource group name to use for this example, if unset a new resource group will be created"

--- a/tests/existing-resources/version.tf
+++ b/tests/existing-resources/version.tf
@@ -7,7 +7,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.79.0"
+      version = "1.89.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -106,8 +106,7 @@ func TestRunExistingResourcesExample(t *testing.T) {
 	existingTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: tempTerraformDir,
 		Vars: map[string]interface{}{
-			"prefix":           prefix,
-			"namespace_region": region,
+			"prefix": prefix,
 		},
 		// Set Upgrade to true to ensure latest version of providers and modules are used by terratest.
 		// This is the same as setting the -upgrade=true flag with terraform.

--- a/version.tf
+++ b/version.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.79.0, < 2.0.0"
+      version = ">= 1.89.0, < 2.0.0"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9.1, < 1.0.0"
-    }
+    #    time = {
+    #      source  = "hashicorp/time"
+    #      version = ">= 0.9.1, < 1.0.0"
+    #    }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -8,9 +8,5 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = ">= 1.89.0, < 2.0.0"
     }
-    #    time = {
-    #      source  = "hashicorp/time"
-    #      version = ">= 0.9.1, < 1.0.0"
-    #    }
   }
 }


### PR DESCRIPTION
### Description

A [provider issue](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6614) has been addressed in 1.89.0 thus a time sleep should not be necessary in this module.
- Bump provider to 1.89.0
- Remove time sleep code, depends and provider
- Fix issue with existing tests not using a defined provider block, since this is now identified and blocks pre-commit check
- Bump common dev assets to include trivy fix, since this now block pre-commit check

Internal issue: 17236

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
